### PR TITLE
fix: Attempt to fix broken paths on GitHub Pages

### DIFF
--- a/docs/_includes/admonition.html
+++ b/docs/_includes/admonition.html
@@ -1,5 +1,6 @@
 {% if false %}
-<!-- Original by Adam Douglas (https://www.adamsdesk.com/posts/admonitions-jekyll/), reused with modifications. -->
+<!-- These comments are wrapped in an if block to prevent these comments from being rendered on GitHub Pages. -->
+<!-- Solution below adapted from Adam Douglas (https://www.adamsdesk.com/posts/admonitions-jekyll/), reused with modifications. -->
 {% endif %}
 
 {% if include.type.size > 0 and include.title.size > 0 %}

--- a/docs/_includes/admonition.html
+++ b/docs/_includes/admonition.html
@@ -1,4 +1,7 @@
+{% if false %}
 <!-- Original by Adam Douglas (https://www.adamsdesk.com/posts/admonitions-jekyll/), reused with modifications. -->
+{% endif %}
+
 {% if include.type.size > 0 and include.title.size > 0 %}
     {% assign types = "note, abstract, info, tip, success, question, warning, failure, danger, bug, example, quote" | split: ", " %}
     {% if types contains include.type and include.body.size > 0 %}

--- a/docs/_sass/admonition.scss
+++ b/docs/_sass/admonition.scss
@@ -65,8 +65,9 @@ $admonitions:
         }
     }
     .admonition.#{$name} .admonition-title::before {
-        -webkit-mask: url("/assets/img/icons/#{$icon}") no-repeat 50% 50%;
-        mask: url("/assets/img/icons/#{$icon}") no-repeat 50% 50%;
+        // Adapted from: https://stackoverflow.com/a/39156436
+        -webkit-mask: url($baseurl + "/assets/img/icons/#{$icon}") no-repeat 50% 50%;
+        mask: url($baseurl + "/assets/img/icons/#{$icon}") no-repeat 50% 50%;
         @if $icon-color {
             background-color: #{$icon-color};
         }

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -2,6 +2,9 @@
 # Only the main Sass file needs front matter (the dashes are enough)
 ---
 
+// Adapted from: https://stackoverflow.com/a/39156436
+$baseurl: "{% if site.baseurl != '/' %}{{ site.baseurl }}{% endif %}";
+
 @import
   "minima/skins/{{ site.minima.skin | default: 'classic' }}",
   "minima/initialize",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

-   [ ] Refactor
-   [ ] Feature
-   [x] Bug Fix
-   [ ] Optimization
-   [x] Documentation Update

## Description

-   Fix broken SVG paths for Admonition icons, using solution from https://stackoverflow.com/a/39156436.

## Related Tickets & Documents

-   Fixes #46 

## Added/updated tests?

_We encourage you to keep the code coverage percentage at 75% and above for new changes._

-   [ ] Yes
-   [x] No, and this is why: Please see deployments on https://87875ab3.coordimate.pages.dev/DraftUserGuide and https://jiakai-17.github.io/tp/DraftUserGuide.html. Both use the same commit hash (https://github.com/AY2324S1-CS2103T-T10-2/tp/commit/e8d58633b74f18ffda682a3782473b6e49559e79 and https://github.com/jiakai-17/tp/commit/e8d58633b74f18ffda682a3782473b6e49559e79)
-   [ ] No, there are UI changes that I'm unable to cover.
-   [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?
