### PR TITLE
fix: Add char limits for addPerson fields

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddPersonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddPersonCommandParser.java
@@ -45,14 +45,14 @@ public class AddPersonCommandParser implements Parser<AddPersonCommand> {
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-        // tag's limit is 30 characters, but we set it to 32 to account for the square brackets that encapsulate it
-        if (name.toString().isEmpty() || name.toString().length() > 100
-                || phone.toString().length() < 3 || phone.toString().length() > 20
-                || email.toString().length() < 6 || address.toString().length() > 200
+        // Phone number's lower limit is 3, but it is tested in PhoneTest.java
+        // Tag's upper limit is 30 characters, but we set it to 32 to account for square brackets that encapsulate it
+        if (name.toString().isEmpty() || name.toString().length() > 100 || phone.toString().length() > 20
+                || email.toString().length() < 5 || email.toString().length() > 100
+                || address.toString().length() > 200
                 || tagList.stream().anyMatch(tag -> tag.toString().length() > 32)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddPersonCommand.MESSAGE_USAGE));
         }
-
         Person person = new Person(name, phone, email, address, tagList);
 
         return new AddPersonCommand(person);

--- a/src/main/java/seedu/address/logic/parser/AddPersonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddPersonCommandParser.java
@@ -45,6 +45,14 @@ public class AddPersonCommandParser implements Parser<AddPersonCommand> {
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
+        // tag's limit is 30 characters, but we set it to 32 to account for the square brackets that encapsulate it
+        if (name.toString().isEmpty() || name.toString().length() > 100
+                || phone.toString().length() < 3 || phone.toString().length() > 20
+                || email.toString().length() < 6 || address.toString().length() > 200
+                || tagList.stream().anyMatch(tag -> tag.toString().length() > 32)) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddPersonCommand.MESSAGE_USAGE));
+        }
+
         Person person = new Person(name, phone, email, address, tagList);
 
         return new AddPersonCommand(person);

--- a/src/test/java/seedu/address/logic/parser/AddPersonCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddPersonCommandParserTest.java
@@ -198,42 +198,42 @@ public class AddPersonCommandParserTest {
     @Test
     public void parse_invalidValueLength_failure() {
         // invalid name (too long)
-        String invalidName = "very".repeat(10) + "long".repeat(25) + "name"; // more than 100 characters
-        assertParseFailure(parser, PREFIX_NAME + invalidName + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                AddPersonCommand.MESSAGE_USAGE));
-
-        // invalid phone (too short)
-        String invalidPhoneShort = "12"; // less than 3 characters
-        assertParseFailure(parser, NAME_DESC_BOB + PREFIX_PHONE + invalidPhoneShort + EMAIL_DESC_BOB
+        String invalidName = "very".repeat(23) + "long name"; // more than 100 characters
+        assertParseFailure(parser, " " + PREFIX_NAME + invalidName + PHONE_DESC_BOB + EMAIL_DESC_BOB
                 + ADDRESS_DESC_BOB
                 + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 AddPersonCommand.MESSAGE_USAGE));
 
         // invalid phone (too long)
         String invalidPhoneLong = "1".repeat(21); // more than 20 characters
-        assertParseFailure(parser, NAME_DESC_BOB + PREFIX_PHONE + invalidPhoneLong + EMAIL_DESC_BOB
+        assertParseFailure(parser, NAME_DESC_BOB + " " + PREFIX_PHONE + invalidPhoneLong + EMAIL_DESC_BOB
                 + ADDRESS_DESC_BOB
                 + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 AddPersonCommand.MESSAGE_USAGE));
 
         // invalid email (too short)
-        String invalidEmailShort = "a@b.c"; // less than 5 characters
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + PREFIX_EMAIL + invalidEmailShort
+        String invalidEmailShort = "t@gg"; // less than 5 characters
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + " " + PREFIX_EMAIL + invalidEmailShort
+                + ADDRESS_DESC_BOB
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                AddPersonCommand.MESSAGE_USAGE));
+
+        // invalid email (too long)
+        String invalidEmailLong = "f" + "12345".repeat(18) + "@gmail.com"; // more than 100 characters
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + " " + PREFIX_EMAIL + invalidEmailLong
                 + ADDRESS_DESC_BOB
                 + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 AddPersonCommand.MESSAGE_USAGE));
 
         // invalid address (too long)
-        String invalidAddress = "123 Fake Street, ".repeat(20); // more than 200 characters
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + PREFIX_ADDRESS
+        String invalidAddress = "123 Fake Street".repeat(14); // more than 200 characters
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + " " + PREFIX_ADDRESS
                 + invalidAddress
                 + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 AddPersonCommand.MESSAGE_USAGE));
 
         // invalid tag (too long)
-        String invalidTag = "friend".repeat(6); // more than 30 characters
+        String invalidTag = "friend".repeat(5) + "1"; // more than 30 characters
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
                 + ADDRESS_DESC_BOB
                 + " " + PREFIX_TAG + invalidTag, String.format(MESSAGE_INVALID_COMMAND_FORMAT,

--- a/src/test/java/seedu/address/logic/parser/AddPersonCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddPersonCommandParserTest.java
@@ -28,6 +28,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalPersons.AMY;
@@ -192,5 +193,50 @@ public class AddPersonCommandParserTest {
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
                         + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddPersonCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidValueLength_failure() {
+        // invalid name (too long)
+        String invalidName = "very".repeat(10) + "long".repeat(25) + "name"; // more than 100 characters
+        assertParseFailure(parser, PREFIX_NAME + invalidName + PHONE_DESC_BOB + EMAIL_DESC_BOB
+                + ADDRESS_DESC_BOB
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                AddPersonCommand.MESSAGE_USAGE));
+
+        // invalid phone (too short)
+        String invalidPhoneShort = "12"; // less than 3 characters
+        assertParseFailure(parser, NAME_DESC_BOB + PREFIX_PHONE + invalidPhoneShort + EMAIL_DESC_BOB
+                + ADDRESS_DESC_BOB
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                AddPersonCommand.MESSAGE_USAGE));
+
+        // invalid phone (too long)
+        String invalidPhoneLong = "1".repeat(21); // more than 20 characters
+        assertParseFailure(parser, NAME_DESC_BOB + PREFIX_PHONE + invalidPhoneLong + EMAIL_DESC_BOB
+                + ADDRESS_DESC_BOB
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                AddPersonCommand.MESSAGE_USAGE));
+
+        // invalid email (too short)
+        String invalidEmailShort = "a@b.c"; // less than 5 characters
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + PREFIX_EMAIL + invalidEmailShort
+                + ADDRESS_DESC_BOB
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                AddPersonCommand.MESSAGE_USAGE));
+
+        // invalid address (too long)
+        String invalidAddress = "123 Fake Street, ".repeat(20); // more than 200 characters
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + PREFIX_ADDRESS
+                + invalidAddress
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                AddPersonCommand.MESSAGE_USAGE));
+
+        // invalid tag (too long)
+        String invalidTag = "friend".repeat(6); // more than 30 characters
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
+                + ADDRESS_DESC_BOB
+                + " " + PREFIX_TAG + invalidTag, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                AddPersonCommand.MESSAGE_USAGE));
     }
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

-   [ ] Refactor
-   [ ] Feature
-   [X] Bug Fix
-   [ ] Optimization
-   [ ] Documentation Update

## Description

-   Add char limits for addPerson fields, noting that email's limit is set at 6 as AB3's requirement for domain name to be at least 2 char.

## Related Tickets & Documents

-   Related Issue #144 

## Added/updated tests?

_We encourage you to keep the code coverage percentage at 75% and above for new changes._

-   [X] Yes
-   [ ] No, and this is why: _please replace this line with details on why tests
        have not been included_
-   [ ] No, there are UI changes that I'm unable to cover.
-   [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?
